### PR TITLE
Correct issues from exiting game view and puzzle menu

### DIFF
--- a/gameview.lua
+++ b/gameview.lua
@@ -273,6 +273,7 @@ function GameView:showGameMenu()
                    self.puzzle:removeIncorrectGuesses()
                    UIManager:close(game_dialog)
                    self:refreshGameView()
+                   UIManager:setDirty(nil, "full")
                end,
             },
          },
@@ -303,12 +304,14 @@ function GameView:showGameMenu()
                callback = function()
                   UIManager:close(game_dialog)
                   UIManager:close(game_view)
+                  UIManager:setDirty(nil, "full")
                end,
             },
          }
       },
       tap_close_callback = function()
          UIManager:close(game_dialog)
+         UIManager:setDirty(nil, "full")
       end,
    }
    UIManager:show(game_dialog)

--- a/library.lua
+++ b/library.lua
@@ -103,10 +103,23 @@ function Library:showDirectoryView(path_to_directory)
             end
       })
    end
-   UIManager:show(KeyValuePage:new{
+   lastView = UIManager:getTopmostVisibleWidget()
+   LibraryPage = KeyValuePage:new{
          title = "Puzzles",
-         kv_pairs = kv_pairs
-   })
+         kv_pairs = kv_pairs,
+         close_callback = function()
+	   if lastView ~= UIManager:getTopmostVisibleWidget() then
+	      UIManager:close(LibraryPage)
+	   else
+	      while (UIManager:getTopmostVisibleWidget() ~= firstView) do
+		UIManager:close(UIManager:getTopmostVisibleWidget())
+	      end
+	      UIManager:close(UIManager:getTopmostVisibleWidget())
+	      UIManager:setDirty(nil, "full")
+	    end
+	 end
+   }
+   UIManager:show(LibraryPage)
 end
 
 return Library

--- a/library.lua
+++ b/library.lua
@@ -115,7 +115,6 @@ function Library:showDirectoryView(path_to_directory)
 		UIManager:close(UIManager:getTopmostVisibleWidget())
 	      end
 	      UIManager:close(UIManager:getTopmostVisibleWidget())
-	      UIManager:setDirty(nil, "full")
 	    end
 	 end
    }

--- a/main.lua
+++ b/main.lua
@@ -58,6 +58,7 @@ function Crossword:getSubMenuItems()
          text = _("Puzzle Library"),
          callback = function()
             self:showLibraryView()
+            firstView = UIManager:getTopmostVisibleWidget()
          end
       },
       {


### PR DESCRIPTION
Removed my previous PR to focus on some straightforward patches.

Should correct issues from exiting game view and puzzle menu:

- Exiting from playing a crossword left UIManager artefacts on screen.
- The puzzle menu could not be exited with a single press of the close button.